### PR TITLE
ElasticSearch Pipeline Tweaks

### DIFF
--- a/ingestion_pipeline/aws_deployment/README.md
+++ b/ingestion_pipeline/aws_deployment/README.md
@@ -19,9 +19,9 @@ aws cloudformation create-stack \
   --parameters ParameterKey=MyHomeIp,ParameterValue=<your ip> \
                ParameterKey=MyKeyPairName,ParameterValue=<your key pair name>
 ```
-Note that you have to give your local IP address. This will (at least initially) restrict access to the EC2
-instance to your home network. Similarly, give the name of an existing EC2 key pair that you have access to. This
-will set up ssh credentials for the EC2 instance.
+Note that you have to give your local IP address, including the cidr block (e.g. 123.45.67.8/32). This will (at 
+least initially) restrict access to the EC2 instance to your home network. Similarly, give the name of an existing EC2
+key pair that you have access to. This will set up ssh credentials for the EC2 instance.
 
 You can monitor the progress of the deployment using
 
@@ -41,7 +41,8 @@ You can update the stack using the same command as above, but with `update-stack
 aws cloudformation update-stack \
   --stack-name doyen-es \
   --template-body file:///full/path/to/doyen/ingestion_pipeline/aws_deployment/template.yaml \
-  --parameters ParameterKey=MyHomeIp,ParameterValue=<your ip>
+  --parameters ParameterKey=MyHomeIp,ParameterValue=<your ip> \
+               ParameterKey=MyKeyPairName,ParameterValue=<your key pair name>
 ```
 
 ## Setting up Docker

--- a/ingestion_pipeline/aws_deployment/template.yaml
+++ b/ingestion_pipeline/aws_deployment/template.yaml
@@ -4,11 +4,11 @@ AWSTemplateFormatVersion: '2010-09-09'
 # Define parameters that will be passed in when the stack is created.
 # Each parameter is assigned using the --parameters flag when the stack is
 # created, using the format ParameterKey=ParameterValue. So for example,
-# to create a stack with the MyHomeIp parameter set to 123.4.5.6, and
-# manually set the AMI you would run:
+# to create a stack with the MyHomeIp parameter set to 123.4.5.6/32 (note the
+# cidr block), and manually set the AMI you would run:
 #  aws cloudformation create-stack --stack-name DoyenStack \
 #    --template-body file://template.yaml \
-#    --parameters ParameterKey=MyHomeIp,ParameterValue=123.4.5.6 \
+#    --parameters ParameterKey=MyHomeIp,ParameterValue=123.4.5.6/32 \
 #                 ParameterKey=AmazonLinux2Ami,ParameterValue=ami-12345678
 Parameters:
   MyHomeIp:

--- a/ingestion_pipeline/doyen_ingestion/pubmed_processor.py
+++ b/ingestion_pipeline/doyen_ingestion/pubmed_processor.py
@@ -96,7 +96,6 @@ def index_pubmed_files(
     file_paths: List[str],
     min_year=None,
     refresh_index: bool = True,
-    require_pub_year=False,
 ):
     """Indexes all the gz files in the provided list_of_files parameter"""
     start = datetime.now()
@@ -125,11 +124,14 @@ def index_pubmed_files(
             detailed_authors=True,
             references_included="pmid",
         )
+
+        # NOTE: we are skipping publications without a publication date. Based on
+        # manual inspection, these appear to be pre-prints.
         recent_articles = [
             article
             for article in articles_by_pmid.values()
-            if (not require_pub_year or article["publication_date"]["year"])
-            or article["publication_date"]["year"] > min_year
+            if article["publication_date"]["year"]
+            and article["publication_date"]["year"] > min_year
         ]
         xml_tree.clear()
 
@@ -233,11 +235,6 @@ def index_pubmed_files(
     is_flag=True,
     help="Optionally do not refresh the index before indexing the files.",
 )
-@click.option(
-    "--require-pub-year",
-    is_flag=True,
-    help="Optionally require that the publication year be present in the XML file.",
-)
 def doyen_ingest_cli(
     start: Optional[int],
     end: Optional[int],
@@ -246,7 +243,6 @@ def doyen_ingest_cli(
     updatefiles_only: bool,
     min_year: int,
     no_refresh_index: bool,
-    require_pub_year: bool,
 ):
     """This CLI helps manage building indexes of the PubMed baseline and update files into ElasticSearch.
 
@@ -297,7 +293,6 @@ def doyen_ingest_cli(
         files_to_index,
         min_year=min_year,
         refresh_index=not no_refresh_index,
-        require_pub_year=require_pub_year,
     )
 
 

--- a/ingestion_pipeline/doyen_ingestion/pubmed_processor.py
+++ b/ingestion_pipeline/doyen_ingestion/pubmed_processor.py
@@ -156,7 +156,7 @@ def index_pubmed_files(
                 recent_articles,
                 index=CONFIG.get("index", "name"),
                 raise_on_error=True,
-                request_timeout=CONFIG.get("elasticsearch", "timeout"),
+                request_timeout=int(CONFIG.get("elasticsearch", "timeout")),
             ):
                 if not is_ok:
                     # If the indexing is not successful, log the error

--- a/ingestion_pipeline/doyen_ingestion/pubmed_processor.py
+++ b/ingestion_pipeline/doyen_ingestion/pubmed_processor.py
@@ -156,7 +156,7 @@ def index_pubmed_files(
                 recent_articles,
                 index=CONFIG.get("index", "name"),
                 raise_on_error=True,
-                timeout=CONFIG.get("elasticsearch", "timeout"),
+                request_timeout=CONFIG.get("elasticsearch", "timeout"),
             ):
                 if not is_ok:
                     # If the indexing is not successful, log the error

--- a/ingestion_pipeline/doyen_ingestion/resources/config_template.ini
+++ b/ingestion_pipeline/doyen_ingestion/resources/config_template.ini
@@ -3,7 +3,7 @@ host = https://localhost:9200
 ca_certs = /path/to/http_ca.crt
 username = elastic
 password = <password>
-timeout = 60s
+timeout = 60
 verify_certs = True
 
 [index]

--- a/ingestion_pipeline/doyen_ingestion/resources/elastic-search-config.json
+++ b/ingestion_pipeline/doyen_ingestion/resources/elastic-search-config.json
@@ -80,7 +80,13 @@
         }
       },
       "references": {
-        "type": "text"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
       }
     }
   }

--- a/ingestion_pipeline/setup.py
+++ b/ingestion_pipeline/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="doyen_ingestion",
-    version="1.0.4",
+    version="1.0.5",
     packages=find_packages(),
     include_package_data=True,
     package_data={"doyen_ingestion": ["resources/*"]},

--- a/ingestion_pipeline/setup.py
+++ b/ingestion_pipeline/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="doyen_ingestion",
-    version="1.0.3",
+    version="1.0.4",
     packages=find_packages(),
     include_package_data=True,
     package_data={"doyen_ingestion": ["resources/*"]},
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         "click",
         "elasticsearch",
-        "indra @ https://github.com/pagreene/indra/archive/get-citations.zip",
+        "indra @ https://github.com/sorgerlab/indra/archive/master.zip",
     ],
     extras_require={"dev": ["pytest", "black", "pytest-mock"]},
     classifiers=[

--- a/ingestion_pipeline/setup.py
+++ b/ingestion_pipeline/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="doyen_ingestion",
-    version="1.0.5",
+    version="1.1.0",
     packages=find_packages(),
     include_package_data=True,
     package_data={"doyen_ingestion": ["resources/*"]},


### PR DESCRIPTION
This PR fixes some minor bugs and makes minor improvements to documentation. In particular:
- Articles that don't have a date are now just skipped to avoid the bugs they create (they are only a minority of the most recent pre-print articles)
- The timeout parameter now works as expected, so that the occasional upload that takes ~30s (as opposed to the usual ~0.5s) doesn't break that upload
- Minor documentation updates.